### PR TITLE
fix type on go example and format the example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,30 +7,30 @@ It monitors incoming traffic, gathers the requests and sends the request to the 
 
 ## How to Integrate:
 Gin example:
-``` go
+
+```go
 package main
 
 import (
-  // Import the apitoolkit golang sdk
-  apitoolkit "github.com/apitoolkit/apitoolkit-go-client"
- )
+  	// Import the apitoolkit golang sdk
+  	apitoolkit "github.com/apitoolkit/apitoolkit-go-client"
+)
 
-func main(){
-  // Initialize the client using your apitoolkit.io generated apikey
-  apitoolkitClient, err := apitoolkit.NewClient(context.Background(), apitoolkit.Config{APIKey: "<APIKEY>"})
+func main() {
+  	// Initialize the client using your apitoolkit.io generated apikey
+  	apitoolkitClient, err := apitoolkit.NewClient(context.Background(), apitoolkit.Config{APIKey: "<APIKEY>"})
 	if err != nil {
-    panic(err)
+    		panic(err)
 	}
 
-  router := gin.New()
+  	router := gin.New()
 
-  // Register with the corresponding middleware of your choice. For Gin router, we use the GinMiddleware method.
-  router.Use(client.GinMiddleware)
+  	// Register with the corresponding middleware of your choice. For Gin router, we use the GinMiddleware method.
+  	router.Use(apitoolkitClient.GinMiddleware)
 
-  // Register your handlers as usual and run the gin server as usual.
-  router.POST("/:slug/test", func(c *gin.Context) {c.Text(200, "ok")})
-  ...
-
+  	// Register your handlers as usual and run the gin server as usual.
+  	router.POST("/:slug/test", func(c *gin.Context) {c.Text(200, "ok")})
+ 	...
 }
 
 ```


### PR DESCRIPTION
- [x] changed `client` to `apitoolkitClient`

- [x] format the indentation of the example code in the readme file.